### PR TITLE
fix mobile make error

### DIFF
--- a/internal/build/gotool.go
+++ b/internal/build/gotool.go
@@ -77,9 +77,10 @@ func (g *GoToolchain) Install(gobin string, args ...string) *exec.Cmd {
 	// the install command.
 	pathTool := g.goTool("env", "GOPATH")
 	output, _ := pathTool.Output()
-	// Trim it because a newline character gets inserted at the end of the output.
-	gopath := strings.TrimSpace(string(output))
-	tool.Env = append(tool.Env, "GOPATH="+gopath)
+	// MODIFIED by Yuuki Endo (mobile make fails)
+    // Trim it because a newline character gets inserted at the end of the output.
+    //tool.Env = append(tool.Env, "GOPATH="+string(output))
+    tool.Env = append(tool.Env, "GOPATH="+strings.TrimSpace(string(output)))
 	return tool
 }
 

--- a/internal/build/gotool.go
+++ b/internal/build/gotool.go
@@ -77,7 +77,9 @@ func (g *GoToolchain) Install(gobin string, args ...string) *exec.Cmd {
 	// the install command.
 	pathTool := g.goTool("env", "GOPATH")
 	output, _ := pathTool.Output()
-	tool.Env = append(tool.Env, "GOPATH="+string(output))
+	// Trim it because a newline character gets inserted at the end of the output.
+	gopath := strings.TrimSpace(string(output))
+	tool.Env = append(tool.Env, "GOPATH="+gopath)
 	return tool
 }
 


### PR DESCRIPTION
## Issue

When running `make ios` or `make android`, the following error occurred:

```
make ios
env GO111MODULE=on go run build/ci.go xcode --local
>>> sdk/go1.22.6/bin/go install -mod=readonly golang.org/x/mobile/cmd/gomobile@latest golang.org/x/mobile/cmd/gobind@latest
go: downloading golang.org/x/mobile v0.0.0-20251113184115-a159579294ab
go: golang.org/x/mobile@v0.0.0-20251113184115-a159579294ab requires go >= 1.24.0; switching to go1.24.10
go: downloading golang.org/x/tools v0.39.0
go: downloading golang.org/x/mod v0.30.0
go: downloading golang.org/x/sync v0.18.0
package golang.org/x/mobile/cmd/gomobile: invalid package directory "{GOPATH}\n/pkg/mod/golang.org/x/mobile@v0.0.0-20251113184115-a159579294ab/cmd/gomobile"
package golang.org/x/mobile/cmd/gobind: invalid package directory "{GOPATH}\n/pkg/mod/golang.org/x/mobile@v0.0.0-20251113184115-a159579294ab/cmd/gobind"
util.go:48: exit status 1
exit status 1
make: *** [ios] Error 1
```

The error message `invalid package directory` appears to be caused by a `\n` being inserted after `GOPATH`.

## Fix

The part of the source code where `GOPATH` is retrieved:

```
pathTool := g.goTool("env", "GOPATH")
output, _ := pathTool.Output()
```

This runs `go env GOPATH`, and because the command outputs a trailing \n, the value is trimmed afterward.