### PR TITLE
cmd,mobile,p2p/elstack: NewElStackVpnConfigに渡すRecvTimeout, KeepAliveI…

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -61,7 +61,9 @@ func main() {
 		elServerAddr    = flag.String("el.serveraddr", "", "address of the EL server")
 		elServerPort    = flag.Int("el.serverport", 0, "port of the EL server")
 		elServerCACert  = flag.String("el.servercacert", "", "file containing EL server's CA certificate")
+		elRecvTimeout   = flag.Int("el.recvtimeout", 0, "EL server receive timeout in seconds (recommended: 180)")
 		elConnTimeout   = flag.Int("el.conntimeout", 0, "EL server connection timeout in seconds (0 = infinite)")
+		elKeepAliveInt  = flag.Int("el.keepaliveinterval", 0, "EL keepalive interval in seconds (recommended: 60)")
 		elCapturePath   = flag.String("el.capturepath", "", "file to store EL packet capture (set to enable packet capture)")
 		// ADDED by Hinata AWAIISHIMA END (EL)
 
@@ -145,17 +147,19 @@ func main() {
 			utils.Fatalf("Failed to read EL server's cert: %v", err)
 		}
 		elCfg := &elstack.ELConfig{
-			Use:           true,
-			ProductName:   "bootnode",
-			HolderVC:      holderVC,
-			HolderPrivKey: holderPrivKey,
-			AntiOverlap:   antiOverlap,
-			IssuerPubKey:  issuerPubKey,
-			ServerAddr:    *elServerAddr,
-			ServerPort:    *elServerPort,
-			ServerCACert:  serverCACert,
-			ConnTimeout:   *elConnTimeout,
-			CapturePath:   *elCapturePath,
+			Use:               true,
+			ProductName:       "bootnode",
+			HolderVC:          holderVC,
+			HolderPrivKey:     holderPrivKey,
+			AntiOverlap:       antiOverlap,
+			IssuerPubKey:      issuerPubKey,
+			ServerAddr:        *elServerAddr,
+			ServerPort:        *elServerPort,
+			ServerCACert:      serverCACert,
+			RecvTimeout:       *elRecvTimeout,
+			ConnTimeout:       *elConnTimeout,
+			KeepAliveInterval: *elKeepAliveInt,
+			CapturePath:       *elCapturePath,
 		}
 		if err := elstack.ValidateELConfig(elCfg); err != nil {
 			utils.Fatalf("Invalid EL config: %v", err)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -167,7 +167,9 @@ var (
 		utils.ELServerAddrFlag,
 		utils.ELServerPortFlag,
 		utils.ELServerCACertFlag,
+		utils.ELRecvTimeoutFlag,
 		utils.ELConnTimeoutFlag,
+		utils.ELKeepAliveIntervalFlag,
 		utils.ELCapturePathFlag,
 		// ADDED by Hinata AWAIISHIMA END (EL)
 		configFileFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -942,9 +942,19 @@ var (
 		Usage:    "File containing EL server's CA certificate",
 		Category: flags.NetworkingCategory,
 	}
+	ELRecvTimeoutFlag = &cli.IntFlag{
+		Name:     "el.recvtimeout",
+		Usage:    "EL server receive timeout in seconds (recommended: 180)",
+		Category: flags.NetworkingCategory,
+	}
 	ELConnTimeoutFlag = &cli.IntFlag{
 		Name:     "el.conntimeout",
 		Usage:    "EL server connection timeout in seconds (0 = infinite)",
+		Category: flags.NetworkingCategory,
+	}
+	ELKeepAliveIntervalFlag = &cli.IntFlag{
+		Name:     "el.keepaliveinterval",
+		Usage:    "EL keepalive interval in seconds (recommended: 60)",
 		Category: flags.NetworkingCategory,
 	}
 	ELCapturePathFlag = &cli.PathFlag{
@@ -1302,8 +1312,14 @@ func setEL(ctx *cli.Context, cfg *p2p.Config) {
 		}
 		cfg.EL.ServerCACert = value
 	}
+	if ctx.IsSet(ELRecvTimeoutFlag.Name) {
+		cfg.EL.RecvTimeout = ctx.Int(ELRecvTimeoutFlag.Name)
+	}
 	if ctx.IsSet(ELConnTimeoutFlag.Name) {
 		cfg.EL.ConnTimeout = ctx.Int(ELConnTimeoutFlag.Name)
+	}
+	if ctx.IsSet(ELKeepAliveIntervalFlag.Name) {
+		cfg.EL.KeepAliveInterval = ctx.Int(ELKeepAliveIntervalFlag.Name)
 	}
 	if ctx.IsSet(ELCapturePathFlag.Name) {
 		cfg.EL.CapturePath = ctx.Path(ELCapturePathFlag.Name)

--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -226,8 +226,18 @@ type NodeConfig struct {
 	ELServerCACert string
 
 	// ADDED by Hinata AWAIISHIMA (EL)
+	// ELRecvTimeout is the EL server receive timeout in seconds.
+	// Recommended value: 180.
+	ELRecvTimeout int
+
+	// ADDED by Hinata AWAIISHIMA (EL)
 	// ELConnTimeout is the EL server connection timeout in seconds (0 = infinite).
 	ELConnTimeout int
+
+	// ADDED by Hinata AWAIISHIMA (EL)
+	// ELKeepAliveInterval is the EL keepalive interval in seconds.
+	// Recommended value: 60.
+	ELKeepAliveInterval int
 
 	// ADDED by Hinata AWAIISHIMA (EL)
 	// ELCapturePath is the file to store EL packet capture (set to enable packet capture).
@@ -403,7 +413,9 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 		el.ServerAddr = config.ELServerAddr
 		el.ServerPort = config.ELServerPort
 		el.ServerCACert = config.ELServerCACert
+		el.RecvTimeout = config.ELRecvTimeout
 		el.ConnTimeout = config.ELConnTimeout
+		el.KeepAliveInterval = config.ELKeepAliveInterval
 		el.CapturePath = config.ELCapturePath
 
 		if err := elstack.ValidateMobileELConfig(&el); err != nil {

--- a/p2p/elstack/config.go
+++ b/p2p/elstack/config.go
@@ -35,9 +35,17 @@ type ELConfig struct {
 	// ServerCACert is the EL server's CA certificate.
 	ServerCACert string
 
+	// RecvTimeout is the EL server receive timeout in seconds.
+	// Recommended value: 180.
+	RecvTimeout int
+
 	// ConnTimeout is the EL server connection timeout in seconds (0 = infinite).
 	// Note that the effective connection timeout is the smaller of ConnTimeout and RecvTimeout.
 	ConnTimeout int
+
+	// KeepAliveInterval is the EL keepalive interval in seconds.
+	// Recommended value: 60.
+	KeepAliveInterval int
 
 	// CapturePath is the file to store EL packet capture (set to enable packet capture).
 	CapturePath string
@@ -72,8 +80,17 @@ func ValidateELConfig(cfg *ELConfig) error {
 	if cfg.ServerPort <= 0 {
 		return fmt.Errorf("ServerPort is not set or invalid")
 	}
+	if cfg.RecvTimeout < 0 {
+		return fmt.Errorf("RecvTimeout is negative")
+	}
 	if cfg.ConnTimeout < 0 {
 		return fmt.Errorf("ConnTimeout is negative")
+	}
+	if cfg.KeepAliveInterval < 0 {
+		return fmt.Errorf("KeepAliveInterval is negative")
+	}
+	if cfg.RecvTimeout < cfg.KeepAliveInterval {
+		return fmt.Errorf("KeepAliveInterval has to be smaller than RecvTimeout")
 	}
 	return nil
 }

--- a/p2p/elstack/elstack.go
+++ b/p2p/elstack/elstack.go
@@ -146,13 +146,13 @@ func SetupEL(cfg *ELConfig, results chan LinkedResult, quit <-chan struct{}) {
 
 	// Create VPN config
 
-	vpnRecvTimeoutSec := uint64(180)
-	vpnKeepAliveIntervalSec := uint64(60)
+	vpnRecvTimeoutSec := uint64(cfg.RecvTimeout)
 	var vpnConnTimeoutSec *uint64
 	if cfg.ConnTimeout > 0 {
 		vpnConnTimeoutUint := uint64(cfg.ConnTimeout)
 		vpnConnTimeoutSec = &vpnConnTimeoutUint
 	}
+	vpnKeepAliveIntervalSec := uint64(cfg.KeepAliveInterval)
 
 	vpnConfig := el_stack.NewElStackVpnConfig(cfg.ServerAddr, strconv.Itoa(cfg.ServerPort), cfg.AntiOverlap,
 		vpnRecvTimeoutSec, vpnConnTimeoutSec, vpnKeepAliveIntervalSec, el_stack.ElStackVpnConnectionTypeQuic,


### PR DESCRIPTION
RecvTimeoutとKeepAliveIntervalの値をコマンドラインとモバイルから指定出来る機能を追加しました。要素の順番はNewElStackVpnConfigに渡す順番と同じにしています。また、RecvTimeoutとKeepAliveIntervalは、0を指定した時にそのまま0秒に設定されるため、これまで利用していた値を推奨値としてコメントに残しています。